### PR TITLE
Fixed the bug with integer values

### DIFF
--- a/demo/js/angular.maskMoney.js
+++ b/demo/js/angular.maskMoney.js
@@ -36,7 +36,14 @@ angular.module('maskMoney', [])
                 function parser() {
                     return $(el).maskMoney('unmasked')[0]
                 }
-                ctrl.$parsers.push(parser)
+                ctrl.$parsers.push(parser);
+                
+                ctrl.$formatters.push(function(value){
+                  $timeout(function(){
+                    init();
+                  });
+                  return parseFloat(value).toFixed(2);
+                });
 
                 function eventHandler() {
                     $timeout(function() {


### PR DESCRIPTION
Fixed the bug that removes the last two decimal houses if the value is a integer or a float like 1.00
